### PR TITLE
Fix API payload to match server's ImportYamlRequest format

### DIFF
--- a/RackPeekInventory/Client/RackPeekClient.cs
+++ b/RackPeekInventory/Client/RackPeekClient.cs
@@ -1,4 +1,6 @@
 using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RackPeekInventory.Models;
@@ -7,7 +9,14 @@ namespace RackPeekInventory.Client;
 
 public class RackPeekClient(HttpClient http, IOptions<InventorySettings> settings, ILogger<RackPeekClient> logger)
 {
-    public async Task<InventoryResponse?> SendAsync(InventoryRequest request, CancellationToken ct = default)
+    internal static readonly JsonSerializerOptions ApiJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public async Task<ImportResponse?> SendAsync(InventoryRequest request, CancellationToken ct = default)
     {
         var cfg = settings.Value;
 
@@ -22,9 +31,11 @@ public class RackPeekClient(HttpClient http, IOptions<InventorySettings> setting
         if (!http.DefaultRequestHeaders.Contains("X-Api-Key"))
             http.DefaultRequestHeaders.Add("X-Api-Key", cfg.ApiKey);
 
+        var payload = BuildApiPayload(request);
+
         logger.LogDebug("Sending inventory for {Hostname} to {ServerUrl}", request.Hostname, cfg.ServerUrl);
 
-        var response = await http.PostAsJsonAsync("/api/inventory", request, ct);
+        var response = await http.PostAsJsonAsync("/api/inventory", payload, ApiJsonOptions, ct);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -33,7 +44,63 @@ public class RackPeekClient(HttpClient http, IOptions<InventorySettings> setting
             return null;
         }
 
-        var result = await response.Content.ReadFromJsonAsync<InventoryResponse>(ct);
+        var result = await response.Content.ReadFromJsonAsync<ImportResponse>(ApiJsonOptions, ct);
         return result;
     }
+
+    public static ImportRequest BuildApiPayload(InventoryRequest data)
+    {
+        var resources = new List<object>();
+
+        // Hardware resource
+        var hardware = new HardwarePayload
+        {
+            Kind = MapHardwareKind(data.HardwareType),
+            Name = data.Hostname,
+            Ipmi = data.Ipmi,
+            Model = data.Model,
+            Cpus = data.Cpus,
+            Drives = data.Drives,
+            Gpus = data.Gpus,
+            Nics = data.Nics,
+            Tags = data.Tags,
+            Labels = data.Labels,
+            Notes = data.Notes,
+        };
+
+        if (data.RamGb != null || data.RamMts != null)
+            hardware.Ram = new RamPayload { Size = data.RamGb, Mts = data.RamMts };
+
+        resources.Add(hardware);
+
+        // System resource (optional — created when system fields are set)
+        if (data.SystemType != null || data.Os != null)
+        {
+            resources.Add(new SystemPayload
+            {
+                Name = data.SystemName ?? $"{data.Hostname}-system",
+                RunsOn = [data.Hostname],
+                Type = data.SystemType,
+                Os = data.Os,
+                Cores = data.Cores,
+                Ram = data.SystemRam,
+                Drives = data.SystemDrives,
+                Tags = data.Tags,
+                Labels = data.Labels,
+            });
+        }
+
+        return new ImportRequest
+        {
+            Json = new ResourceRoot { Resources = resources }
+        };
+    }
+
+    private static string MapHardwareKind(string type) => type.ToLowerInvariant() switch
+    {
+        "server" => "Server",
+        "desktop" => "Desktop",
+        "laptop" => "Laptop",
+        _ => char.ToUpperInvariant(type[0]) + type[1..]
+    };
 }

--- a/RackPeekInventory/Models/ImportRequest.cs
+++ b/RackPeekInventory/Models/ImportRequest.cs
@@ -1,0 +1,51 @@
+namespace RackPeekInventory.Models;
+
+/// <summary>
+/// API request payload matching the server's ImportYamlRequest format.
+/// </summary>
+public class ImportRequest
+{
+    public ResourceRoot? Json { get; set; }
+}
+
+public class ResourceRoot
+{
+    public int Version { get; set; } = 2;
+    public List<object> Resources { get; set; } = new();
+}
+
+public class HardwarePayload
+{
+    public string Kind { get; set; } = "Server";
+    public required string Name { get; set; }
+    public string[]? Tags { get; set; }
+    public Dictionary<string, string>? Labels { get; set; }
+    public string? Notes { get; set; }
+    public RamPayload? Ram { get; set; }
+    public bool? Ipmi { get; set; }
+    public string? Model { get; set; }
+    public List<InventoryCpu>? Cpus { get; set; }
+    public List<InventoryDrive>? Drives { get; set; }
+    public List<InventoryGpu>? Gpus { get; set; }
+    public List<InventoryNic>? Nics { get; set; }
+}
+
+public class SystemPayload
+{
+    public string Kind { get; set; } = "System";
+    public required string Name { get; set; }
+    public List<string>? RunsOn { get; set; }
+    public string[]? Tags { get; set; }
+    public Dictionary<string, string>? Labels { get; set; }
+    public string? Type { get; set; }
+    public string? Os { get; set; }
+    public int? Cores { get; set; }
+    public double? Ram { get; set; }
+    public List<InventoryDrive>? Drives { get; set; }
+}
+
+public class RamPayload
+{
+    public double? Size { get; set; }
+    public int? Mts { get; set; }
+}

--- a/RackPeekInventory/Models/InventoryResponse.cs
+++ b/RackPeekInventory/Models/InventoryResponse.cs
@@ -1,14 +1,13 @@
 namespace RackPeekInventory.Models;
 
-public class InventoryResponse
+/// <summary>
+/// API response matching the server's ImportYamlResponse format.
+/// </summary>
+public class ImportResponse
 {
-    public ResourceResult Hardware { get; set; } = new();
-    public ResourceResult? System { get; set; }
-}
-
-public class ResourceResult
-{
-    public string Name { get; set; } = string.Empty;
-    public string Kind { get; set; } = string.Empty;
-    public string Action { get; set; } = string.Empty;
+    public List<string> Added { get; set; } = new();
+    public List<string> Updated { get; set; } = new();
+    public List<string> Replaced { get; set; } = new();
+    public Dictionary<string, string> OldYaml { get; set; } = new();
+    public Dictionary<string, string> NewYaml { get; set; } = new();
 }

--- a/RackPeekInventory/Program.cs
+++ b/RackPeekInventory/Program.cs
@@ -48,12 +48,9 @@ else
 
     if (isDryRun)
     {
-        var json = JsonSerializer.Serialize(data, new JsonSerializerOptions
-        {
-            WriteIndented = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-        });
+        var payload = RackPeekClient.BuildApiPayload(data);
+        var dryRunOptions = new JsonSerializerOptions(RackPeekClient.ApiJsonOptions) { WriteIndented = true };
+        var json = JsonSerializer.Serialize(payload, dryRunOptions);
         Console.WriteLine(json);
         return;
     }
@@ -70,14 +67,15 @@ else
 
     if (result != null)
     {
-        logger.LogInformation("{Action} {Kind} '{Name}'",
-            result.Hardware.Action, result.Hardware.Kind, result.Hardware.Name);
+        foreach (var name in result.Added)
+            logger.LogInformation("Added '{Name}'", name);
+        foreach (var name in result.Updated)
+            logger.LogInformation("Updated '{Name}'", name);
+        foreach (var name in result.Replaced)
+            logger.LogInformation("Replaced '{Name}'", name);
 
-        if (result.System != null)
-        {
-            logger.LogInformation("{Action} {Kind} '{Name}'",
-                result.System.Action, result.System.Kind, result.System.Name);
-        }
+        if (result.Added.Count == 0 && result.Updated.Count == 0 && result.Replaced.Count == 0)
+            logger.LogInformation("No changes");
     }
     else
     {

--- a/RackPeekInventory/Worker/InventoryWorker.cs
+++ b/RackPeekInventory/Worker/InventoryWorker.cs
@@ -27,14 +27,15 @@ public class InventoryWorker(
 
                 if (result != null)
                 {
-                    logger.LogInformation("{Action} {Kind} '{Name}'",
-                        result.Hardware.Action, result.Hardware.Kind, result.Hardware.Name);
+                    foreach (var name in result.Added)
+                        logger.LogInformation("Added '{Name}'", name);
+                    foreach (var name in result.Updated)
+                        logger.LogInformation("Updated '{Name}'", name);
+                    foreach (var name in result.Replaced)
+                        logger.LogInformation("Replaced '{Name}'", name);
 
-                    if (result.System != null)
-                    {
-                        logger.LogInformation("{Action} {Kind} '{Name}'",
-                            result.System.Action, result.System.Kind, result.System.Name);
-                    }
+                    if (result.Added.Count == 0 && result.Updated.Count == 0 && result.Replaced.Count == 0)
+                        logger.LogInformation("No changes");
                 }
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/Tests/Client/RackPeekClientTests.cs
+++ b/Tests/Client/RackPeekClientTests.cs
@@ -23,10 +23,7 @@ public class RackPeekClientTests
         var handler = new MockHttpHandler((req, _) =>
         {
             capturedApiKey = req.Headers.GetValues("X-Api-Key").FirstOrDefault();
-            var response = new InventoryResponse
-            {
-                Hardware = new ResourceResult { Name = "srv01", Kind = "Server", Action = "created" }
-            };
+            var response = new ImportResponse { Added = ["srv01"] };
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = JsonContent.Create(response, options: JsonOptions)
@@ -51,10 +48,7 @@ public class RackPeekClientTests
         var handler = new MockHttpHandler((req, _) =>
         {
             capturedUri = req.RequestUri;
-            var response = new InventoryResponse
-            {
-                Hardware = new ResourceResult { Name = "srv01", Kind = "Server", Action = "created" }
-            };
+            var response = new ImportResponse { Added = ["srv01"] };
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = JsonContent.Create(response, options: JsonOptions)
@@ -115,10 +109,9 @@ public class RackPeekClientTests
     {
         var handler = new MockHttpHandler((_, _) =>
         {
-            var response = new InventoryResponse
+            var response = new ImportResponse
             {
-                Hardware = new ResourceResult { Name = "srv01", Kind = "Server", Action = "created" },
-                System = new ResourceResult { Name = "srv01-system", Kind = "System", Action = "created" }
+                Added = ["srv01", "srv01-system"],
             };
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {
@@ -135,11 +128,126 @@ public class RackPeekClientTests
         var result = await client.SendAsync(new InventoryRequest { Hostname = "srv01" });
 
         Assert.NotNull(result);
-        Assert.Equal("srv01", result.Hardware.Name);
-        Assert.Equal("Server", result.Hardware.Kind);
-        Assert.Equal("created", result.Hardware.Action);
-        Assert.NotNull(result.System);
-        Assert.Equal("srv01-system", result.System.Name);
+        Assert.Equal(["srv01", "srv01-system"], result.Added);
+        Assert.Empty(result.Updated);
+        Assert.Empty(result.Replaced);
+    }
+
+    [Fact]
+    public void BuildApiPayload_creates_hardware_resource()
+    {
+        var data = new InventoryRequest
+        {
+            Hostname = "srv01",
+            HardwareType = "server",
+            RamGb = 64,
+            RamMts = 3200,
+            Ipmi = true,
+            Model = "ProLiant DL380",
+            Cpus = [new InventoryCpu { Model = "Xeon Gold", Cores = 16, Threads = 32 }],
+            Drives = [new InventoryDrive { Type = "nvme", Size = 512 }],
+            Gpus = [new InventoryGpu { Model = "RTX 4000", Vram = 16 }],
+            Nics = [new InventoryNic { Type = "rj45", Speed = 1.0, Ports = 2 }],
+            Tags = ["prod"],
+            Labels = new Dictionary<string, string> { ["env"] = "production" },
+        };
+
+        var payload = RackPeekClient.BuildApiPayload(data);
+
+        Assert.NotNull(payload.Json);
+        Assert.Equal(2, payload.Json.Version);
+        Assert.Single(payload.Json.Resources); // no system fields → only hardware
+
+        var hw = Assert.IsType<HardwarePayload>(payload.Json.Resources[0]);
+        Assert.Equal("Server", hw.Kind);
+        Assert.Equal("srv01", hw.Name);
+        Assert.NotNull(hw.Ram);
+        Assert.Equal(64, hw.Ram.Size);
+        Assert.Equal(3200, hw.Ram.Mts);
+        Assert.True(hw.Ipmi);
+        Assert.Equal("ProLiant DL380", hw.Model);
+        Assert.Single(hw.Cpus!);
+        Assert.Equal("Xeon Gold", hw.Cpus![0].Model);
+        Assert.Single(hw.Drives!);
+        Assert.Single(hw.Gpus!);
+        Assert.Single(hw.Nics!);
+        Assert.Equal(["prod"], hw.Tags);
+        Assert.Equal("production", hw.Labels!["env"]);
+    }
+
+    [Fact]
+    public void BuildApiPayload_creates_system_resource_when_system_fields_set()
+    {
+        var data = new InventoryRequest
+        {
+            Hostname = "srv01",
+            HardwareType = "server",
+            SystemType = "baremetal",
+            Os = "Ubuntu 22.04",
+            Cores = 32,
+            SystemRam = 64,
+            SystemDrives = [new InventoryDrive { Type = "nvme", Size = 512 }],
+        };
+
+        var payload = RackPeekClient.BuildApiPayload(data);
+
+        Assert.Equal(2, payload.Json!.Resources.Count);
+
+        var sys = Assert.IsType<SystemPayload>(payload.Json.Resources[1]);
+        Assert.Equal("System", sys.Kind);
+        Assert.Equal("srv01-system", sys.Name);
+        Assert.Equal(["srv01"], sys.RunsOn);
+        Assert.Equal("baremetal", sys.Type);
+        Assert.Equal("Ubuntu 22.04", sys.Os);
+        Assert.Equal(32, sys.Cores);
+        Assert.Equal(64, sys.Ram);
+        Assert.Single(sys.Drives!);
+    }
+
+    [Fact]
+    public void BuildApiPayload_maps_hardware_kind_correctly()
+    {
+        var serverPayload = RackPeekClient.BuildApiPayload(new InventoryRequest { Hostname = "h", HardwareType = "server" });
+        var desktopPayload = RackPeekClient.BuildApiPayload(new InventoryRequest { Hostname = "h", HardwareType = "desktop" });
+        var laptopPayload = RackPeekClient.BuildApiPayload(new InventoryRequest { Hostname = "h", HardwareType = "laptop" });
+
+        Assert.Equal("Server", ((HardwarePayload)serverPayload.Json!.Resources[0]).Kind);
+        Assert.Equal("Desktop", ((HardwarePayload)desktopPayload.Json!.Resources[0]).Kind);
+        Assert.Equal("Laptop", ((HardwarePayload)laptopPayload.Json!.Resources[0]).Kind);
+    }
+
+    [Fact]
+    public void BuildApiPayload_serializes_to_expected_json()
+    {
+        var data = new InventoryRequest
+        {
+            Hostname = "srv01",
+            HardwareType = "server",
+            RamGb = 32,
+            SystemType = "baremetal",
+            Os = "Ubuntu 22.04",
+        };
+
+        var payload = RackPeekClient.BuildApiPayload(data);
+        var json = JsonSerializer.Serialize(payload, RackPeekClient.ApiJsonOptions);
+        using var doc = JsonDocument.Parse(json);
+
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("json", out var jsonProp));
+        Assert.Equal(2, jsonProp.GetProperty("version").GetInt32());
+
+        var resources = jsonProp.GetProperty("resources");
+        Assert.Equal(2, resources.GetArrayLength());
+
+        var hw = resources[0];
+        Assert.Equal("Server", hw.GetProperty("kind").GetString());
+        Assert.Equal("srv01", hw.GetProperty("name").GetString());
+        Assert.Equal(32, hw.GetProperty("ram").GetProperty("size").GetDouble());
+
+        var sys = resources[1];
+        Assert.Equal("System", sys.GetProperty("kind").GetString());
+        Assert.Equal("srv01-system", sys.GetProperty("name").GetString());
+        Assert.Equal("baremetal", sys.GetProperty("type").GetString());
     }
 
     private static RackPeekClient CreateClient(MockHttpHandler handler, InventorySettings settings)


### PR DESCRIPTION
The client was sending a flat InventoryRequest directly to /api/inventory, but the server expects an ImportYamlRequest with a nested JSON structure containing a ResourceRoot with versioned resources.

Changes:

- RackPeekClient: Add BuildApiPayload() to transform InventoryRequest into the server's expected ImportRequest format with HardwarePayload and SystemPayload resources. Send payload with camelCase JSON serialization and null-value exclusion via ApiJsonOptions.

- ImportRequest (new): Add DTOs matching the server's resource schema - ImportRequest, ResourceRoot, HardwarePayload, SystemPayload, RamPayload. Includes hardware kind mapping (server/desktop/laptop) and optional system resource creation when OS or system type is set.

- InventoryResponse → ImportResponse: Replace the old per-resource response model with the server's actual ImportYamlResponse format using Added/Updated/Replaced string lists and OldYaml/NewYaml diffs.

- Program.cs: Dry-run mode now serializes the actual API payload instead of the raw InventoryRequest. Result logging iterates Added/Updated/ Replaced lists instead of accessing fixed Hardware/System properties.

- InventoryWorker: Mirror the same result logging changes for daemon mode.

- Tests: Update RackPeekClientTests for the new response model and add tests for BuildApiPayload covering hardware resource creation, system resource generation, hardware kind mapping, and JSON serialization format.